### PR TITLE
Release 1.0. Add 'auto' mode.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "istream": "cpp",
         "ostream": "cpp",
         "system_error": "cpp",
-        "typeinfo": "cpp"
+        "typeinfo": "cpp",
+        "array": "cpp"
     }
 }

--- a/lib/CAN_Motor/CAN_Motor.h
+++ b/lib/CAN_Motor/CAN_Motor.h
@@ -10,7 +10,14 @@
 class CanMotor{
     public:
         CanMotor(const uint8_t _CS, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
+        CanMotor(const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
+
         bool initialize(const CAN_SPEED can_speed = CAN_1000KBPS, CAN_CLOCK can_clock = MCP_16MHZ);
+        
+        void handleInterrupt(void);
+        void startInterrupt(void (*ISR_callback)(void));
+        void (*ISR_callback)();
+        
         virtual bool setCurrentPositionAsOrigin() = 0;
         virtual bool turnOn() = 0;
         virtual bool turnOff()= 0;
@@ -31,6 +38,7 @@ class CanMotor{
         float m_velocity;
         float m_torque;
         const char * m_name;
+        const uint8_t m_interrupt_pin;
         can_frame response_msg;
         MCP2515 m_mcp2515;
         //Protected methods.

--- a/lib/CAN_Motor/CAN_Motor.h
+++ b/lib/CAN_Motor/CAN_Motor.h
@@ -9,12 +9,11 @@
 
 class CanMotor{
     public:
-        CanMotor(const uint8_t _CS, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
         CanMotor(const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
 
         bool initialize(const CAN_SPEED can_speed = CAN_1000KBPS, CAN_CLOCK can_clock = MCP_16MHZ);
         
-        void handleInterrupt(void);
+        virtual void handleInterrupt(void) = 0;
         void startInterrupt(void (*ISR_callback)(void));
         void (*ISR_callback)();
         

--- a/lib/CAN_Motor/CAN_Motor.h
+++ b/lib/CAN_Motor/CAN_Motor.h
@@ -5,6 +5,7 @@
 #include <mcp2515.h>
 
 #define DEBUG_ENABLED 1
+#define MILLIS_LIMIT_UNTIL_RETRY 50
 
 
 class CanMotor{
@@ -43,6 +44,8 @@ class CanMotor{
         const uint8_t m_interrupt_pin;
         bool m_is_auto_mode_running = false;
         float m_torque_setpoint;
+        unsigned long m_last_response_time_ms = 0;
+        //unsigned long m_last_msg_sent_time_ms = 0;
         can_frame response_msg;
         //Protected methods.
         bool m_sendAndReceiveBlocking(const can_frame & can_msg , unsigned long timeout_us);

--- a/lib/CAN_Motor/CAN_Motor.h
+++ b/lib/CAN_Motor/CAN_Motor.h
@@ -19,7 +19,6 @@ class CanMotor{
         bool readMotorResponse(unsigned long timeout_us);
         void startAutoMode(void (*ISR_callback)(void));
         void stopAutoMode();
-        void (*ISR_callback)();
 
         virtual void handleInterrupt(void) = 0;        
         virtual bool setCurrentPositionAsOrigin() = 0;

--- a/lib/CAN_Motor/CAN_Motor.h
+++ b/lib/CAN_Motor/CAN_Motor.h
@@ -12,45 +12,48 @@ class CanMotor{
     public:
         CanMotor(const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
 
+        //Public member functions defined by the base class (this one).
         bool initialize(const CAN_SPEED can_speed = CAN_1000KBPS, CAN_CLOCK can_clock = MCP_16MHZ);
-        virtual bool setTorque(float torque_setpoint) = 0;
-        virtual bool setTorque(float torque_setpoint, unsigned long timeout_us) = 0;
         bool readMotorResponse();
         bool readMotorResponse(unsigned long timeout_us);
         void startAutoMode(void (*ISR_callback)(void));
         void stopAutoMode();
 
-        virtual void handleInterrupt(void) = 0;        
-        virtual bool setCurrentPositionAsOrigin() = 0;
+        //Public member functions that each derived class must define.
         virtual bool turnOn() = 0;
         virtual bool turnOff()= 0;
+        virtual bool setTorque(float torque_setpoint) = 0;
+        virtual bool setTorque(float torque_setpoint, unsigned long timeout_us) = 0;
         virtual bool setCurrentPositionAsZero() = 0;
+        virtual bool setCurrentPositionAsOrigin() = 0;
+        virtual void handleInterrupt(void) = 0;        
+
         //Public "getters" to motor response variables. 
         float position() const {return m_position - m_offset_from_zero_motor;}
         const float & velocity() const {return m_velocity;}
         const float & torque() const {return m_torque;}
         const char* name() const {return m_name;}
 
-        MCP2515 m_mcp2515;  //Temporarily put here for debugging purposes. MOVE TO PROTECTED.
-
 
     protected:
+        //Protected member variables.
         float m_position;
-        float m_offset_from_zero_motor;
         float m_velocity;
         float m_torque;
         const char * m_name;
+        float m_offset_from_zero_motor;
         const uint8_t m_interrupt_pin;
-        bool m_is_auto_mode_running = false;
-        float m_torque_setpoint;
-        unsigned long m_last_response_time_ms = false;
-        bool m_is_ready_to_send = true;
-        //unsigned long m_last_msg_sent_time_ms = 0;
+        bool m_is_auto_mode_running;
+        unsigned long m_last_response_time_ms;
+        bool m_is_ready_to_send;
+        MCP2515 m_mcp2515;
         can_frame response_msg;
-        //Protected methods.
+        
+        //Protected member functions defined by the base class (this one).
         bool m_sendAndReceiveBlocking(const can_frame & can_msg , unsigned long timeout_us);
         void m_emptyMCP2515buffer();
+        
+        //Protected member functions that each derived class must define.
         virtual bool m_sendTorque(float torque_setpoint) = 0;
         virtual bool m_readMotorResponse() = 0;
-
 };

--- a/lib/CAN_Motor/CAN_Motor.h
+++ b/lib/CAN_Motor/CAN_Motor.h
@@ -13,8 +13,8 @@ class CanMotor{
         CanMotor(const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
 
         bool initialize(const CAN_SPEED can_speed = CAN_1000KBPS, CAN_CLOCK can_clock = MCP_16MHZ);
-        bool setTorque(float torque_setpoint);
-        bool setTorque(float torque_setpoint, unsigned long timeout_us);
+        virtual bool setTorque(float torque_setpoint) = 0;
+        virtual bool setTorque(float torque_setpoint, unsigned long timeout_us) = 0;
         bool readMotorResponse();
         bool readMotorResponse(unsigned long timeout_us);
         void startAutoMode(void (*ISR_callback)(void));
@@ -44,7 +44,8 @@ class CanMotor{
         const uint8_t m_interrupt_pin;
         bool m_is_auto_mode_running = false;
         float m_torque_setpoint;
-        unsigned long m_last_response_time_ms = 0;
+        unsigned long m_last_response_time_ms = false;
+        bool m_is_ready_to_send = true;
         //unsigned long m_last_msg_sent_time_ms = 0;
         can_frame response_msg;
         //Protected methods.

--- a/lib/CAN_Motor/CAN_Motor.h
+++ b/lib/CAN_Motor/CAN_Motor.h
@@ -12,24 +12,27 @@ class CanMotor{
         CanMotor(const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
 
         bool initialize(const CAN_SPEED can_speed = CAN_1000KBPS, CAN_CLOCK can_clock = MCP_16MHZ);
-        
-        virtual void handleInterrupt(void) = 0;
-        void startInterrupt(void (*ISR_callback)(void));
+        bool setTorque(float torque_setpoint);
+        bool setTorque(float torque_setpoint, unsigned long timeout_us);
+        bool readMotorResponse();
+        bool readMotorResponse(unsigned long timeout_us);
+        void startAutoMode(void (*ISR_callback)(void));
+        void stopAutoMode();
         void (*ISR_callback)();
-        
+
+        virtual void handleInterrupt(void) = 0;        
         virtual bool setCurrentPositionAsOrigin() = 0;
         virtual bool turnOn() = 0;
         virtual bool turnOff()= 0;
         virtual bool setCurrentPositionAsZero() = 0;
-        virtual bool setTorque(float torque_setpoint) = 0;
-        virtual bool setTorque(float torque_setpoint, unsigned long timeout_us) = 0;
-        virtual bool readMotorResponse() = 0;
-        virtual bool readMotorResponse(unsigned long timeout_us) = 0;
         //Public "getters" to motor response variables. 
         float position() const {return m_position - m_offset_from_zero_motor;}
         const float & velocity() const {return m_velocity;}
         const float & torque() const {return m_torque;}
         const char* name() const {return m_name;}
+
+        MCP2515 m_mcp2515;  //Temporarily put here for debugging purposes. MOVE TO PROTECTED.
+
 
     protected:
         float m_position;
@@ -38,11 +41,13 @@ class CanMotor{
         float m_torque;
         const char * m_name;
         const uint8_t m_interrupt_pin;
+        bool m_is_auto_mode_running = false;
+        float m_torque_setpoint;
         can_frame response_msg;
-        MCP2515 m_mcp2515;
         //Protected methods.
         bool m_sendAndReceiveBlocking(const can_frame & can_msg , unsigned long timeout_us);
         void m_emptyMCP2515buffer();
-
+        virtual bool m_sendTorque(float torque_setpoint) = 0;
+        virtual bool m_readMotorResponse() = 0;
 
 };

--- a/lib/CAN_Motor/CAN_Motor.h
+++ b/lib/CAN_Motor/CAN_Motor.h
@@ -18,6 +18,7 @@ class CanMotor{
         bool readMotorResponse(unsigned long timeout_us);
         void startAutoMode(void (*ISR_callback)(void));
         void stopAutoMode();
+        void handleInterrupt(void);        
 
         //Public member functions that each derived class must define.
         virtual bool turnOn() = 0;
@@ -26,7 +27,6 @@ class CanMotor{
         virtual bool setTorque(float torque_setpoint, unsigned long timeout_us) = 0;
         virtual bool setCurrentPositionAsZero() = 0;
         virtual bool setCurrentPositionAsOrigin() = 0;
-        virtual void handleInterrupt(void) = 0;        
 
         //Public "getters" to motor response variables. 
         float position() const {return m_position - m_offset_from_zero_motor;}

--- a/lib/CAN_Motor/CAN_Motor.h
+++ b/lib/CAN_Motor/CAN_Motor.h
@@ -46,6 +46,7 @@ class CanMotor{
         bool m_is_auto_mode_running;
         unsigned long m_last_response_time_ms;
         bool m_is_ready_to_send;
+        unsigned long m_last_retry_time_ms;
         MCP2515 m_mcp2515;
         can_frame response_msg;
         

--- a/lib/CAN_Motor/Can_Motor.cpp
+++ b/lib/CAN_Motor/Can_Motor.cpp
@@ -41,21 +41,17 @@ bool CanMotor::initialize(const CAN_SPEED can_speed, CAN_CLOCK can_clock)
 
 
 
-
-
 void CanMotor::startAutoMode(void (*ISR_callback)(void)){
-    this->ISR_callback = ISR_callback;      
     m_is_auto_mode_running = true;
     m_is_ready_to_send = true;
     m_emptyMCP2515buffer();
     m_mcp2515.clearInterrupts();
     pinMode(m_interrupt_pin, INPUT);
     attachInterrupt(digitalPinToInterrupt(m_interrupt_pin), ISR_callback, FALLING);
-    //SPI.usingInterrupt(digitalPinToInterrupt(m_interrupt_pin));
     m_last_response_time_ms = millis();
     return;
 }
-
+ 
 
 void CanMotor::stopAutoMode()
 {

--- a/lib/CAN_Motor/Can_Motor.cpp
+++ b/lib/CAN_Motor/Can_Motor.cpp
@@ -1,10 +1,6 @@
 #include "CAN_Motor.h"
 
 
-CanMotor::CanMotor(const uint8_t _CS,const char * motor_name, SPIClass & spi, const bool doBegin)
-    : m_interrupt_pin(99), m_name(motor_name), m_mcp2515{_CS, spi, doBegin}, m_torque(0), m_position(0), m_velocity(0), m_offset_from_zero_motor(0)
-{
-}
 
 
 CanMotor::CanMotor(const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name, SPIClass & spi, const bool doBegin)
@@ -45,32 +41,7 @@ bool CanMotor::initialize(const CAN_SPEED can_speed, CAN_CLOCK can_clock)
 }
 
 
-/*
-void CanMotor::irqHandler() 
-{
-    Serial.println("\nINTERRUPT RECEIVED\n");
-    //readMotorResponse();
-}
-*/
 
-
-/*
-void CanMotor::startInterrupt(void (*ISR_callback)(void)){
-    attachInterrupt(m_interrupt_pin, [](){
-        Serial.println("\nINTERRUPT RECEIVED IN CLASS\n");
-        //Serial.println(this->m_position);
-    }
-    , FALLING);  
-}
-*/
-
-void CanMotor::handleInterrupt(void)
-{
-    Serial.println("\n\n!!!Received Interruptuc!!!\n\n");
-    //Serial.print("My name is: "); Serial.println(m_name);
-    readMotorResponse();
-    setTorque(0);
-}
 
 
 
@@ -78,11 +49,7 @@ void CanMotor::startInterrupt(void (*ISR_callback)(void)){
     attachInterrupt(m_interrupt_pin, ISR_callback, FALLING);  
 }
 
-/*
-void CanMotor::startInterrupt(){
-    attachInterrupt(m_interrupt_pin, std::bind(&CanMotor::irqHandler,this), FALLING);  
-}
-*/
+
 
 
 bool CanMotor::m_sendAndReceiveBlocking(const can_frame & can_msg , unsigned long timeout_us)

--- a/lib/CAN_Motor/Can_Motor.cpp
+++ b/lib/CAN_Motor/Can_Motor.cpp
@@ -64,6 +64,7 @@ bool CanMotor::readMotorResponse(unsigned long timeout_us)
 
 
 void CanMotor::startAutoMode(void (*ISR_callback)(void)){
+    //Serial.print(m_name); Serial.println("Started auto mode"); 
     m_is_auto_mode_running = true;
     m_is_ready_to_send = true;
     m_emptyMCP2515buffer();
@@ -73,7 +74,7 @@ void CanMotor::startAutoMode(void (*ISR_callback)(void)){
     m_last_response_time_ms = millis();
     return;
 }
- 
+
 
 
 void CanMotor::stopAutoMode()
@@ -114,6 +115,7 @@ void CanMotor::handleInterrupt(void)
     m_readMotorResponse();
     m_is_ready_to_send = true;
 }
+
 
 
 bool CanMotor::m_sendAndReceiveBlocking(const can_frame & can_msg , unsigned long timeout_us)

--- a/lib/CAN_Motor/Can_Motor.cpp
+++ b/lib/CAN_Motor/Can_Motor.cpp
@@ -1,15 +1,17 @@
 #include "CAN_Motor.h"
 
 
-
-
-
 CanMotor::CanMotor(const uint8_t _CS,const char * motor_name, SPIClass & spi, const bool doBegin)
-    : m_name(motor_name), m_mcp2515{_CS, spi, doBegin}, m_torque(0), m_position(0), m_velocity(0), m_offset_from_zero_motor(0)
+    : m_interrupt_pin(99), m_name(motor_name), m_mcp2515{_CS, spi, doBegin}, m_torque(0), m_position(0), m_velocity(0), m_offset_from_zero_motor(0)
 {
 }
 
 
+CanMotor::CanMotor(const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name, SPIClass & spi, const bool doBegin)
+    : m_interrupt_pin(_INT_PIN), m_name(motor_name), m_mcp2515{_CS, spi, doBegin}, m_torque(0), m_position(0), m_velocity(0), m_offset_from_zero_motor(0)
+{
+
+}
 
 
 
@@ -42,6 +44,45 @@ bool CanMotor::initialize(const CAN_SPEED can_speed, CAN_CLOCK can_clock)
     return true;
 }
 
+
+/*
+void CanMotor::irqHandler() 
+{
+    Serial.println("\nINTERRUPT RECEIVED\n");
+    //readMotorResponse();
+}
+*/
+
+
+/*
+void CanMotor::startInterrupt(void (*ISR_callback)(void)){
+    attachInterrupt(m_interrupt_pin, [](){
+        Serial.println("\nINTERRUPT RECEIVED IN CLASS\n");
+        //Serial.println(this->m_position);
+    }
+    , FALLING);  
+}
+*/
+
+void CanMotor::handleInterrupt(void)
+{
+    Serial.println("\n\n!!!Received Interruptuc!!!\n\n");
+    //Serial.print("My name is: "); Serial.println(m_name);
+    readMotorResponse();
+    setTorque(0);
+}
+
+
+
+void CanMotor::startInterrupt(void (*ISR_callback)(void)){
+    attachInterrupt(m_interrupt_pin, ISR_callback, FALLING);  
+}
+
+/*
+void CanMotor::startInterrupt(){
+    attachInterrupt(m_interrupt_pin, std::bind(&CanMotor::irqHandler,this), FALLING);  
+}
+*/
 
 
 bool CanMotor::m_sendAndReceiveBlocking(const can_frame & can_msg , unsigned long timeout_us)

--- a/lib/CAN_Motor/Can_Motor.cpp
+++ b/lib/CAN_Motor/Can_Motor.cpp
@@ -2,7 +2,6 @@
 
 
 
-
 CanMotor::CanMotor(const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name, SPIClass & spi, const bool doBegin)
     : m_interrupt_pin(_INT_PIN), m_name(motor_name), m_mcp2515{_CS, spi, doBegin}, m_torque(0), m_position(0), m_velocity(0), m_offset_from_zero_motor(0)
 {
@@ -45,11 +44,14 @@ bool CanMotor::initialize(const CAN_SPEED can_speed, CAN_CLOCK can_clock)
 
 
 void CanMotor::startAutoMode(void (*ISR_callback)(void)){
+    this->ISR_callback = ISR_callback;      
     m_is_auto_mode_running = true;
     m_emptyMCP2515buffer();
     m_mcp2515.clearInterrupts();
     pinMode(m_interrupt_pin, INPUT);
     attachInterrupt(digitalPinToInterrupt(m_interrupt_pin), ISR_callback, FALLING);
+    SPI.usingInterrupt(digitalPinToInterrupt(m_interrupt_pin));
+    m_last_response_time_ms = millis();
     m_sendTorque(m_torque_setpoint); 
     return;
 }
@@ -81,7 +83,28 @@ bool CanMotor::setTorque(float torque_setpoint, unsigned long timeout_us){
 bool CanMotor::setTorque(float torque_setpoint )
 {
     m_torque_setpoint = torque_setpoint;
-    return (m_is_auto_mode_running ? true : m_sendTorque(m_torque_setpoint));
+    //return (m_is_auto_mode_running ? true : m_sendTorque(m_torque_setpoint));
+    if(m_is_auto_mode_running)
+    {
+        if ((millis() - m_last_response_time_ms) < MILLIS_LIMIT_UNTIL_RETRY) //In auto mode, test if we received response 
+        {
+            Serial.println("All Ok, auto mode running normally");
+            return true; //Everything OK. Motor doesn't need communication "recovery"
+        }
+        else
+        {
+            Serial.print("\t Millis: "); Serial.print(millis()); Serial.print("\tLast message"); Serial.print(m_last_response_time_ms); Serial.print("\tRetrying to recover "); Serial.println(m_name); 
+            //m_emptyMCP2515buffer();
+            m_mcp2515.clearRXnOVRFlags();
+            m_mcp2515.clearERRIF();
+            m_mcp2515.clearMERR();
+            m_mcp2515.clearInterrupts();
+            m_last_response_time_ms = millis();
+            if (m_sendTorque(m_torque_setpoint)) {Serial.print("IN CLASS: Sent torque successfully to "); Serial.println(m_name); return true;}
+            else {Serial.print("IN CLASS: FAILED Sending torque to "); Serial.println(m_name); return false;}
+        }
+    }
+    return m_sendTorque(m_torque_setpoint);
 }
 
 
@@ -108,6 +131,7 @@ bool CanMotor::readMotorResponse()
 
 bool CanMotor::m_sendAndReceiveBlocking(const can_frame & can_msg , unsigned long timeout_us)
 {
+    stopAutoMode();
     m_emptyMCP2515buffer();
     MCP2515::ERROR response_code;
     unsigned long t_ini = micros();

--- a/lib/MIT_Motors/MitMotor.cpp
+++ b/lib/MIT_Motors/MitMotor.cpp
@@ -32,20 +32,24 @@ void MitMotor::handleInterrupt(void)
     if (irq & MCP2515::CANINTF_MERRF)
     {
         Serial.print("\n\n!!!!!ERROR MERF (ERROR IN MESSAGE TRANSMISSION OR RECEPTION)!!!"); Serial.print(m_name); Serial.print("\n\n");
+        cli();
         m_mcp2515.clearMERR();
         m_mcp2515.clearInterrupts();
+        sei();
     }
     if (irq & MCP2515::CANINTF_ERRIF)
     {
         //uint8_t err = m_mcp2515.getErrorFlags();
         Serial.print("\n\n!!!!!!!ERROR BUFFER FULL!!!!!!"); Serial.print(m_name); Serial.print("\n\n");
         //m_emptyMCP2515buffer();
+        cli();
         m_mcp2515.clearRXnOVRFlags();
         m_mcp2515.clearERRIF();
         m_mcp2515.clearInterrupts();
+        sei();
     }
     m_readMotorResponse();
-    m_sendTorque(m_torque_setpoint);
+    m_is_ready_to_send = true;
 }
 
 
@@ -105,6 +109,56 @@ bool MitMotor::setCurrentPositionAsZero()
 
 
 
+bool MitMotor::setTorque(float torque_setpoint, unsigned long timeout_us){
+    if (m_is_auto_mode_running) 
+    {
+        return setTorque(torque_setpoint);
+    }
+    bool was_message_sent;
+    unsigned long t_ini = micros();
+    while(!(was_message_sent = setTorque(torque_setpoint)) and (micros()-t_ini) < timeout_us)
+    {
+        //Serial.println("Send Retry!");           
+    }
+    return was_message_sent;
+}
+
+
+//Refactor this function.
+bool MitMotor::setTorque(float torque_setpoint )
+{
+    m_torque_setpoint = torque_setpoint;
+    if(m_is_auto_mode_running)
+    {
+        if (m_is_ready_to_send)
+        {
+            m_is_ready_to_send = false;
+            return m_sendTorque(m_torque_setpoint);
+        }
+
+        else if ((millis() - m_last_response_time_ms) < MILLIS_LIMIT_UNTIL_RETRY) //In auto mode, test if we received response 
+        {
+            //Serial.println("All Ok, auto mode running normally");
+            return true; //Everything OK. Motor doesn't need communication "recovery"
+        }
+        else
+        {
+            //Serial.print("\t Millis: "); Serial.print(millis()); Serial.print("\tLast message"); Serial.print(m_last_response_time_ms); Serial.print("\tRetrying to recover "); Serial.println(m_name); 
+            cli();
+            m_emptyMCP2515buffer();
+            // m_mcp2515.clearRXnOVRFlags();
+            // m_mcp2515.clearERRIF();
+            // m_mcp2515.clearMERR();
+            //m_mcp2515.clearInterrupts();
+            sei();
+            m_last_response_time_ms = millis();
+            m_sendTorque(m_torque_setpoint);
+            return false;
+        }
+    }
+    return m_sendTorque(m_torque_setpoint);
+}
+
 
 bool MitMotor::m_sendTorque(float torque_setpoint)
 {
@@ -125,13 +179,18 @@ bool MitMotor::m_sendTorque(float torque_setpoint)
     can_msg.data[6] = t_int >> 8;
     can_msg.data[7] = t_int & 0xFF;
     //m_mcp2515.clearInterrupts();
-    return m_mcp2515.sendMessage(&can_msg) == MCP2515::ERROR_OK ? true : false;
+    cli();
+    bool result = (m_mcp2515.sendMessage(&can_msg) == MCP2515::ERROR_OK); 
+    sei();
+    return result;
 }
 
 
 
 bool MitMotor::m_readMotorResponse(){
+    cli();
     MCP2515::ERROR response_code = m_mcp2515.readMessage(&response_msg);
+    sei();
     if(response_code != MCP2515::ERROR::ERROR_OK)
     {
         return false;

--- a/lib/MIT_Motors/MitMotor.cpp
+++ b/lib/MIT_Motors/MitMotor.cpp
@@ -22,6 +22,11 @@ MitMotor::MitMotor(const MotorType & motor_type, const uint8_t _CS,const char * 
 {
 }
 
+MitMotor::MitMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name, SPIClass & spi, const bool doBegin)
+    : CanMotor{_CS, _INT_PIN, motor_name, spi, doBegin}, m_motor_type(motor_type) 
+{
+}
+
 
 bool MitMotor::turnOn()
 {

--- a/lib/MIT_Motors/MitMotor.cpp
+++ b/lib/MIT_Motors/MitMotor.cpp
@@ -26,18 +26,19 @@ MitMotor::MitMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_
 
 void MitMotor::handleInterrupt(void)
 {
+    m_last_response_time_ms = millis();
     uint8_t irq = m_mcp2515.getInterrupts();
     //Serial.println(irq,BIN);
     if (irq & MCP2515::CANINTF_MERRF)
     {
-        Serial.println("\n\n!!!!!ERROR MERF (ERROR IN MESSAGE TRANSMISSION OR RECEPTION)!!!\n\n");
+        Serial.print("\n\n!!!!!ERROR MERF (ERROR IN MESSAGE TRANSMISSION OR RECEPTION)!!!"); Serial.print(m_name); Serial.print("\n\n");
         m_mcp2515.clearMERR();
         m_mcp2515.clearInterrupts();
     }
     if (irq & MCP2515::CANINTF_ERRIF)
     {
         //uint8_t err = m_mcp2515.getErrorFlags();
-        Serial.println("\n\n!!!!!!!ERROR BUFFER FULL!!!!!!\n\n");
+        Serial.print("\n\n!!!!!!!ERROR BUFFER FULL!!!!!!"); Serial.print(m_name); Serial.print("\n\n");
         //m_emptyMCP2515buffer();
         m_mcp2515.clearRXnOVRFlags();
         m_mcp2515.clearERRIF();
@@ -50,6 +51,7 @@ void MitMotor::handleInterrupt(void)
 
 bool MitMotor::turnOn()
 {
+    stopAutoMode();
     can_frame can_msg;
     can_msg.can_id  = 0x01;
     can_msg.can_dlc = 0x08;
@@ -67,6 +69,7 @@ bool MitMotor::turnOn()
 
 bool MitMotor::turnOff()
 {
+    stopAutoMode();
     can_frame can_msg;
     can_msg.can_id  = 0x01;
     can_msg.can_dlc = 0x08;
@@ -84,6 +87,7 @@ bool MitMotor::turnOff()
 
 bool MitMotor::setCurrentPositionAsZero()
 {
+    stopAutoMode();
     can_frame can_msg;
     can_msg.can_id  = 0x01;
     can_msg.can_dlc = 0x08;
@@ -100,9 +104,6 @@ bool MitMotor::setCurrentPositionAsZero()
 }
 
 
-
-
-//HERE
 
 
 bool MitMotor::m_sendTorque(float torque_setpoint)
@@ -123,7 +124,7 @@ bool MitMotor::m_sendTorque(float torque_setpoint)
     can_msg.data[5] = 0x0;
     can_msg.data[6] = t_int >> 8;
     can_msg.data[7] = t_int & 0xFF;
-    m_mcp2515.clearInterrupts();
+    //m_mcp2515.clearInterrupts();
     return m_mcp2515.sendMessage(&can_msg) == MCP2515::ERROR_OK ? true : false;
 }
 

--- a/lib/MIT_Motors/MitMotor.cpp
+++ b/lib/MIT_Motors/MitMotor.cpp
@@ -82,15 +82,14 @@ bool MitMotor::setTorque(float torque_setpoint )
         else
         {
             //Serial.print("\t Millis: "); Serial.print(millis()); Serial.print("\tLast message"); Serial.print(m_last_response_time_ms); Serial.print("\tRetrying to recover "); Serial.println(m_name); 
-            cli();
-            m_emptyMCP2515buffer();
-            // m_mcp2515.clearRXnOVRFlags();
-            // m_mcp2515.clearERRIF();
-            // m_mcp2515.clearMERR();
-            //m_mcp2515.clearInterrupts();
-            sei();
-            //m_last_response_time_ms = millis();
-            m_sendTorque(torque_setpoint);
+            if ((millis() - m_last_retry_time_ms) > MILLIS_LIMIT_UNTIL_RETRY)
+            {
+                m_last_retry_time_ms = millis();
+                cli();
+                m_emptyMCP2515buffer();
+                sei();
+                m_sendTorque(torque_setpoint);
+            }
             return false;
         }
     }

--- a/lib/MIT_Motors/MitMotor.cpp
+++ b/lib/MIT_Motors/MitMotor.cpp
@@ -17,14 +17,19 @@ const float MitMotor::MotorType::KD_MIN = 0.0f;
 const float MitMotor::MotorType::KD_MAX = 5.0f;
 
 
-MitMotor::MitMotor(const MotorType & motor_type, const uint8_t _CS,const char * motor_name, SPIClass & spi, const bool doBegin)
-    : CanMotor{_CS, motor_name, spi, doBegin}, m_motor_type(motor_type) 
+
+MitMotor::MitMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name, SPIClass & spi, const bool doBegin)
+    : m_motor_type(motor_type), CanMotor{_CS, _INT_PIN, motor_name, spi, doBegin}
 {
 }
 
-MitMotor::MitMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name, SPIClass & spi, const bool doBegin)
-    : CanMotor{_CS, _INT_PIN, motor_name, spi, doBegin}, m_motor_type(motor_type) 
+
+void MitMotor::handleInterrupt(void)
 {
+    //Serial.println("\n!!!Response from:");
+    //Serial.println(m_name); Serial.println("\n" );
+    readMotorResponse();
+    setTorque(0);
 }
 
 

--- a/lib/MIT_Motors/MitMotor.cpp
+++ b/lib/MIT_Motors/MitMotor.cpp
@@ -142,36 +142,6 @@ bool MitMotor::setCurrentPositionAsOrigin(){
 
 
 
-void MitMotor::handleInterrupt(void)
-{
-    m_last_response_time_ms = millis();
-    uint8_t irq = m_mcp2515.getInterrupts();
-    //Serial.println(irq,BIN);
-    if (irq & MCP2515::CANINTF_MERRF)
-    {
-        Serial.print("\n\n!!!!!ERROR MERF (ERROR IN MESSAGE TRANSMISSION OR RECEPTION)!!!"); Serial.print(m_name); Serial.print("\n\n");
-        cli();
-        m_mcp2515.clearMERR();
-        m_mcp2515.clearInterrupts();
-        sei();
-    }
-    if (irq & MCP2515::CANINTF_ERRIF)
-    {
-        //uint8_t err = m_mcp2515.getErrorFlags();
-        Serial.print("\n\n!!!!!!!ERROR BUFFER FULL!!!!!!"); Serial.print(m_name); Serial.print("\n\n");
-        //m_emptyMCP2515buffer();
-        cli();
-        m_mcp2515.clearRXnOVRFlags();
-        m_mcp2515.clearERRIF();
-        m_mcp2515.clearInterrupts();
-        sei();
-    }
-    m_readMotorResponse();
-    m_is_ready_to_send = true;
-}
-
-
-
 bool MitMotor::m_sendTorque(float torque_setpoint)
 {
     can_frame can_msg;

--- a/lib/MIT_Motors/MitMotor.cpp
+++ b/lib/MIT_Motors/MitMotor.cpp
@@ -151,7 +151,7 @@ bool MitMotor::setTorque(float torque_setpoint )
             // m_mcp2515.clearMERR();
             //m_mcp2515.clearInterrupts();
             sei();
-            m_last_response_time_ms = millis();
+            //m_last_response_time_ms = millis();
             m_sendTorque(m_torque_setpoint);
             return false;
         }

--- a/lib/MIT_Motors/MitMotor.h
+++ b/lib/MIT_Motors/MitMotor.h
@@ -32,10 +32,8 @@ class MitMotor : public CanMotor{
         bool turnOn() override;
         bool turnOff() override;
         bool setCurrentPositionAsZero() override;
-        bool setTorque(float torque_setpoint) override;
-        bool setTorque(float torque_setpoint, unsigned long timeout_us) override;
-        bool readMotorResponse() override;
-        bool readMotorResponse(unsigned long timeout_us) override;
+        //bool readMotorResponse() override;
+        //bool readMotorResponse(unsigned long timeout_us) override;
         bool setCurrentPositionAsOrigin() override;
 
         //Public member functions exclusive for MIT Motors.
@@ -48,5 +46,7 @@ class MitMotor : public CanMotor{
         //Private member functions
         unsigned int m_float_to_uint(float x, float x_min, float x_max);
         float m_uint_to_float(unsigned int x_int, float x_min, float x_max, int bits);
+        bool m_sendTorque(float torque_setpoint);
+        bool m_readMotorResponse() override;
 
 };

--- a/lib/MIT_Motors/MitMotor.h
+++ b/lib/MIT_Motors/MitMotor.h
@@ -28,6 +28,7 @@ class MitMotor : public CanMotor{
 
         //Public member functions common for all CAN motors:
         MitMotor(const MotorType & motor_type, const uint8_t _CS, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
+        MitMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
         bool turnOn() override;
         bool turnOff() override;
         bool setCurrentPositionAsZero() override;

--- a/lib/MIT_Motors/MitMotor.h
+++ b/lib/MIT_Motors/MitMotor.h
@@ -27,8 +27,8 @@ class MitMotor : public CanMotor{
         static const MotorType GIM;
 
         //Public member functions common for all CAN motors:
-        MitMotor(const MotorType & motor_type, const uint8_t _CS, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
         MitMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
+        void handleInterrupt(void);
         bool turnOn() override;
         bool turnOff() override;
         bool setCurrentPositionAsZero() override;

--- a/lib/MIT_Motors/MitMotor.h
+++ b/lib/MIT_Motors/MitMotor.h
@@ -5,7 +5,6 @@
 #include <SPI.h>
 #include <mcp2515.h>
 
-#define DEBUG_ENABLED 1
 
 class MitMotor : public CanMotor{
     public:
@@ -26,29 +25,27 @@ class MitMotor : public CanMotor{
         static const MotorType AK_10;
         static const MotorType GIM;
 
-        //Public member functions common for all CAN motors:
         MitMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_NAME", SPIClass & spi = SPI, const bool doBegin = true);
-        void handleInterrupt(void);
+
+        //Public member functions that this class defines (overrides from the base):
         bool turnOn() override;
         bool turnOff() override;
+        bool setTorque(float torque_setpoint) override;
+        bool setTorque(float torque_setpoint, unsigned long timeout_us) override;
         bool setCurrentPositionAsZero() override;
-        bool setTorque(float torque_setpoint);
-        bool setTorque(float torque_setpoint, unsigned long timeout_us);
-        //bool readMotorResponse() override;
-        //bool readMotorResponse(unsigned long timeout_us) override;
         bool setCurrentPositionAsOrigin() override;
+        void handleInterrupt(void);
 
-        //Public member functions exclusive for MIT Motors.
 
     private:
         //Private member variables
         const MotorType m_motor_type;
 
-
-        //Private member functions
-        unsigned int m_float_to_uint(float x, float x_min, float x_max);
-        float m_uint_to_float(unsigned int x_int, float x_min, float x_max, int bits);
-        bool m_sendTorque(float torque_setpoint);
+        //Private member functions that this class defines (overrides from the base):
+        bool m_sendTorque(float torque_setpoint) override;
         bool m_readMotorResponse() override;
 
+        //Private member functions exclusive for MIT Motors.
+        unsigned int m_float_to_uint(float x, float x_min, float x_max);
+        float m_uint_to_float(unsigned int x_int, float x_min, float x_max, int bits);
 };

--- a/lib/MIT_Motors/MitMotor.h
+++ b/lib/MIT_Motors/MitMotor.h
@@ -32,6 +32,8 @@ class MitMotor : public CanMotor{
         bool turnOn() override;
         bool turnOff() override;
         bool setCurrentPositionAsZero() override;
+        bool setTorque(float torque_setpoint);
+        bool setTorque(float torque_setpoint, unsigned long timeout_us);
         //bool readMotorResponse() override;
         //bool readMotorResponse(unsigned long timeout_us) override;
         bool setCurrentPositionAsOrigin() override;

--- a/lib/MIT_Motors/MitMotor.h
+++ b/lib/MIT_Motors/MitMotor.h
@@ -34,7 +34,6 @@ class MitMotor : public CanMotor{
         bool setTorque(float torque_setpoint, unsigned long timeout_us) override;
         bool setCurrentPositionAsZero() override;
         bool setCurrentPositionAsOrigin() override;
-        void handleInterrupt(void);
 
 
     private:

--- a/lib/Machine_State/machine_state.cpp
+++ b/lib/Machine_State/machine_state.cpp
@@ -12,5 +12,6 @@ void print_menu()
     Serial.print(INPUT_SET_TORQUE_AND_READ - '0'); Serial.print(") Enviar y leer continuamente \n");
     Serial.print(INPUT_SET_POS_ORIGIN - '0'); Serial.print(") Establecer position actual como Origen\n");
     Serial.print(INPUT_SET_POS_ZERO - '0'); Serial.print(") Establecer position actual como Zero \n");
+    Serial.print((byte)(INPUT_INITIALIZE)); Serial.print(") Inicializar (resetear e INICIALIZAR MCP DE LOS MOTORES) \n");
 
 }

--- a/lib/Machine_State/machine_state.cpp
+++ b/lib/Machine_State/machine_state.cpp
@@ -12,6 +12,6 @@ void print_menu()
     Serial.print(INPUT_SET_TORQUE_AND_READ - '0'); Serial.print(") Enviar y leer continuamente \n");
     Serial.print(INPUT_SET_POS_ORIGIN - '0'); Serial.print(") Establecer position actual como Origen\n");
     Serial.print(INPUT_SET_POS_ZERO - '0'); Serial.print(") Establecer position actual como Zero \n");
-    Serial.print((byte)(INPUT_INITIALIZE)); Serial.print(") Inicializar (resetear e INICIALIZAR MCP DE LOS MOTORES) \n");
-
+    Serial.print((byte)(INPUT_AUTO_MODE_ON)); Serial.print(") Iniciar modo automatico \n");
+    Serial.print((byte)(INPUT_AUTO_MODE_OFF)); Serial.print(") Detener modo automatico \n");
 }

--- a/lib/Machine_State/machine_state.h
+++ b/lib/Machine_State/machine_state.h
@@ -15,7 +15,8 @@ enum MachineStates
     SET_TORQUE,
     SET_TORQUE_AND_READ,
     SET_POS_ORIGIN, 
-    SET_POS_ZERO
+    SET_POS_ZERO,
+    INITIALIZE
 };
 
 
@@ -30,7 +31,8 @@ enum MachineSerialInputs : char
     INPUT_SET_TORQUE = '6',
     INPUT_SET_TORQUE_AND_READ = '7',
     INPUT_SET_POS_ORIGIN = '8',
-    INPUT_SET_POS_ZERO  = '9'
+    INPUT_SET_POS_ZERO  = '9',
+    INPUT_INITIALIZE  = 'a'
 
 };
 

--- a/lib/Machine_State/machine_state.h
+++ b/lib/Machine_State/machine_state.h
@@ -16,7 +16,8 @@ enum MachineStates
     SET_TORQUE_AND_READ,
     SET_POS_ORIGIN, 
     SET_POS_ZERO,
-    INITIALIZE
+    START_AUTO_MODE,
+    STOP_AUTO_MODE
 };
 
 
@@ -32,8 +33,8 @@ enum MachineSerialInputs : char
     INPUT_SET_TORQUE_AND_READ = '7',
     INPUT_SET_POS_ORIGIN = '8',
     INPUT_SET_POS_ZERO  = '9',
-    INPUT_INITIALIZE  = 'a'
-
+    INPUT_AUTO_MODE_ON  = 'a', 
+    INPUT_AUTO_MODE_OFF = 'b'
 };
 
 void print_menu(void);

--- a/lib/RMD_Motor/RmdMotor.cpp
+++ b/lib/RMD_Motor/RmdMotor.cpp
@@ -174,7 +174,7 @@ bool RmdMotor::setTorque(float torque_setpoint )
             // m_mcp2515.clearMERR();
             //m_mcp2515.clearInterrupts();
             sei();
-            m_last_response_time_ms = millis();
+            //m_last_response_time_ms = millis();
             if (m_curr_state == 0)
             {
                 //Serial.println("Sending torque");
@@ -293,7 +293,7 @@ bool RmdMotor::requestPosition()
             // m_mcp2515.clearMERR();
             //m_mcp2515.clearInterrupts();
             sei();
-            m_last_response_time_ms = millis();
+            //m_last_response_time_ms = millis();
             m_requestPosition();
             return false;
         }

--- a/lib/RMD_Motor/RmdMotor.cpp
+++ b/lib/RMD_Motor/RmdMotor.cpp
@@ -214,12 +214,14 @@ bool RmdMotor::requestPosition()
         else
         {
             //Serial.print("Retrying to recover requestPosition "); Serial.println(m_name);
-            //m_emptyMCP2515buffer();
-            m_mcp2515.clearRXnOVRFlags();
-            m_mcp2515.clearERRIF();
-            m_mcp2515.clearMERR();
-            m_mcp2515.clearInterrupts();
+            m_emptyMCP2515buffer();
+            // m_mcp2515.clearRXnOVRFlags();
+            // m_mcp2515.clearERRIF();
+            // m_mcp2515.clearMERR();
+            //m_mcp2515.clearInterrupts();
             m_last_response_time_ms = millis();
+            m_requestPosition();
+            return false;
         }
     }
     return m_requestPosition();

--- a/lib/RMD_Motor/RmdMotor.cpp
+++ b/lib/RMD_Motor/RmdMotor.cpp
@@ -151,13 +151,11 @@ bool RmdMotor::setTorque(float torque_setpoint )
             m_is_ready_to_send = false;
             if (m_curr_state == 0)
             {
-                //Serial.println("Sending torque");
                 m_curr_state = 1;
                 return m_sendTorque(torque_setpoint);
             }
             else
             {
-                //Serial.println("Requesting position");
                 m_curr_state = 0;
                 return m_requestPosition();
             }
@@ -169,26 +167,23 @@ bool RmdMotor::setTorque(float torque_setpoint )
         }
         else
         {
-            //Serial.print("\t Millis: "); Serial.print(millis()); Serial.print("\tLast message"); Serial.print(m_last_response_time_ms); Serial.print("\tRetrying to recover "); Serial.println(m_name); 
-            cli();
-            m_emptyMCP2515buffer();
-            // m_mcp2515.clearRXnOVRFlags();
-            // m_mcp2515.clearERRIF();
-            // m_mcp2515.clearMERR();
-            //m_mcp2515.clearInterrupts();
-            sei();
-            //m_last_response_time_ms = millis();
-            if (m_curr_state == 0)
+            if ((millis() - m_last_retry_time_ms) > MILLIS_LIMIT_UNTIL_RETRY)
             {
-                //Serial.println("Sending torque");
-                m_curr_state = 1;
-                m_sendTorque(torque_setpoint);
-            }
-            else
-            {
-                //Serial.println("Requesting position");
-                m_curr_state = 0;
-                m_requestPosition();
+                m_last_retry_time_ms = millis();
+                //Serial.print("\t Millis: "); Serial.print(millis()); Serial.print("\tLast message"); Serial.print(m_last_response_time_ms); Serial.print("\tRetrying to recover "); Serial.println(m_name); 
+                cli();
+                m_emptyMCP2515buffer();
+                sei();
+                if (m_curr_state == 0)
+                {
+                    m_curr_state = 1;
+                    m_sendTorque(torque_setpoint);
+                }
+                else
+                {
+                    m_curr_state = 0;
+                    m_requestPosition();
+                }
             }
             return false;
         }

--- a/lib/RMD_Motor/RmdMotor.cpp
+++ b/lib/RMD_Motor/RmdMotor.cpp
@@ -86,9 +86,27 @@ union torque_msg_rx
 };
 
 
-RmdMotor::RmdMotor(const MotorType & motor_type, const uint8_t _CS,const char * motor_name, SPIClass & spi, const bool doBegin)
-    : CanMotor{_CS, motor_name, spi, doBegin}, m_motor_type(motor_type) 
+RmdMotor::RmdMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name, SPIClass & spi, const bool doBegin)
+    : m_motor_type(motor_type), CanMotor{_CS, _INT_PIN, motor_name, spi, doBegin}
 {
+}
+
+
+void RmdMotor::handleInterrupt(void)
+{
+    readMotorResponse();
+    if (m_curr_state == 0)
+    {
+        //Serial.println("Sending torque");
+        setTorque(0);
+        m_curr_state = 1;
+    }
+    else
+    {
+        //Serial.println("Requesting position");
+        requestPosition();
+        m_curr_state = 0;
+    }
 }
 
 

--- a/lib/RMD_Motor/RmdMotor.cpp
+++ b/lib/RMD_Motor/RmdMotor.cpp
@@ -255,36 +255,6 @@ bool RmdMotor::setCurrentPositionAsOrigin(){
 
 
 
-void RmdMotor::handleInterrupt(void)
-{
-    m_last_response_time_ms = millis();
-    uint8_t irq = m_mcp2515.getInterrupts();
-    //Serial.println(irq,BIN);
-    if (irq & MCP2515::CANINTF_MERRF)
-    {
-        Serial.print("\n\n!!!!!ERROR MERF (ERROR IN MESSAGE TRANSMISSION OR RECEPTION)!!!"); Serial.print(m_name); Serial.print("\n\n");
-        cli();
-        m_mcp2515.clearMERR();
-        m_mcp2515.clearInterrupts();
-        sei();
-    }
-    if (irq & MCP2515::CANINTF_ERRIF)
-    {
-        //uint8_t err = m_mcp2515.getErrorFlags();
-        Serial.print("\n\n!!!!!!!ERROR BUFFER FULL!!!!!!"); Serial.print(m_name); Serial.print("\n\n");
-        //m_emptyMCP2515buffer();
-        cli();
-        m_mcp2515.clearRXnOVRFlags();
-        m_mcp2515.clearERRIF();
-        m_mcp2515.clearInterrupts();
-        sei();
-    }
-    m_readMotorResponse();
-    m_is_ready_to_send = true;
-}
-
-
-
 bool RmdMotor::requestPosition()
 {
     return (m_is_auto_mode_running ? true : m_requestPosition());

--- a/lib/RMD_Motor/RmdMotor.cpp
+++ b/lib/RMD_Motor/RmdMotor.cpp
@@ -287,30 +287,7 @@ void RmdMotor::handleInterrupt(void)
 
 bool RmdMotor::requestPosition()
 {
-    //return (m_is_auto_mode_running ? true : m_requestPosition());
-    if(m_is_auto_mode_running)
-    {
-        if ((millis() - m_last_response_time_ms) < MILLIS_LIMIT_UNTIL_RETRY) //In auto mode, test if we received response 
-        {
-            //Serial.println("All Ok, auto mode running normally");
-            return true; //Everything OK. Motor doesn't need communication "recovery"
-        }
-        else
-        {
-            //Serial.print("Retrying to recover requestPosition "); Serial.println(m_name);
-            cli();
-            m_emptyMCP2515buffer();
-            // m_mcp2515.clearRXnOVRFlags();
-            // m_mcp2515.clearERRIF();
-            // m_mcp2515.clearMERR();
-            //m_mcp2515.clearInterrupts();
-            sei();
-            //m_last_response_time_ms = millis();
-            m_requestPosition();
-            return false;
-        }
-    }
-    return m_requestPosition();
+    return (m_is_auto_mode_running ? true : m_requestPosition());
 }
 
 

--- a/lib/RMD_Motor/RmdMotor.h
+++ b/lib/RMD_Motor/RmdMotor.h
@@ -26,7 +26,8 @@ class RmdMotor : public CanMotor{
         bool requestPosition();
 
         //Public member functions shared by all CAN motor types. 
-        RmdMotor(const MotorType & motor_type, const uint8_t _CS, const char * motor_name = "DEFAULT_RMD", SPIClass & spi = SPI, const bool doBegin = true);
+        RmdMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_RMD", SPIClass & spi = SPI, const bool doBegin = true);
+        void handleInterrupt(void);
         bool turnOn() override;
         bool turnOff() override;
         bool setCurrentPositionAsZero() override;
@@ -41,6 +42,7 @@ class RmdMotor : public CanMotor{
         //Private member variables
         const MotorType m_motor_type;
         uint8_t m_temperature;
+        volatile bool m_curr_state = 0;
 
 
 

--- a/lib/RMD_Motor/RmdMotor.h
+++ b/lib/RMD_Motor/RmdMotor.h
@@ -31,7 +31,6 @@ class RmdMotor : public CanMotor{
         bool setTorque(float torque_setpoint, unsigned long timeout_us) override;
         bool setCurrentPositionAsZero() override;
         bool setCurrentPositionAsOrigin() override;
-        void handleInterrupt(void) override;
 
         //Public member functions exlusive for RMD motors
         bool requestPosition();

--- a/lib/RMD_Motor/RmdMotor.h
+++ b/lib/RMD_Motor/RmdMotor.h
@@ -31,18 +31,19 @@ class RmdMotor : public CanMotor{
         bool turnOn() override;
         bool turnOff() override;
         bool setCurrentPositionAsZero() override;
-        bool setTorque(float torque_setpoint) override;
-        bool setTorque(float torque_setpoint, unsigned long timeout_us) override;
-        bool readMotorResponse() override;
-        bool readMotorResponse(unsigned long timeout_us) override;
         bool setCurrentPositionAsOrigin() override;
-
 
     private:
         //Private member variables
         const MotorType m_motor_type;
         uint8_t m_temperature;
         volatile bool m_curr_state = 0;
+
+        bool m_sendTorque(float torque_setpoint);
+        bool m_requestPosition();
+        bool m_readMotorResponse() override;
+
+
 
 
 

--- a/lib/RMD_Motor/RmdMotor.h
+++ b/lib/RMD_Motor/RmdMotor.h
@@ -22,18 +22,20 @@ class RmdMotor : public CanMotor{
         static const MotorType RMD_X8_PRO_V3;
         static const MotorType RMD_L5015;
 
+        RmdMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_RMD", SPIClass & spi = SPI, const bool doBegin = true);
+
+        //Public member functions that this class defines (overrides from the base):
+        bool turnOn() override;
+        bool turnOff() override;
+        bool setTorque(float torque_setpoint) override;
+        bool setTorque(float torque_setpoint, unsigned long timeout_us) override;
+        bool setCurrentPositionAsZero() override;
+        bool setCurrentPositionAsOrigin() override;
+        void handleInterrupt(void) override;
+
         //Public member functions exlusive for RMD motors
         bool requestPosition();
 
-        //Public member functions shared by all CAN motor types. 
-        RmdMotor(const MotorType & motor_type, const uint8_t _CS, const uint8_t _INT_PIN, const char * motor_name = "DEFAULT_RMD", SPIClass & spi = SPI, const bool doBegin = true);
-        void handleInterrupt(void);
-        bool turnOn() override;
-        bool turnOff() override;
-        bool setCurrentPositionAsZero() override;
-        bool setCurrentPositionAsOrigin() override;
-        bool setTorque(float torque_setpoint) override;
-        bool setTorque(float torque_setpoint, unsigned long timeout_us) override;
 
     private:
         //Private member variables
@@ -41,12 +43,10 @@ class RmdMotor : public CanMotor{
         uint8_t m_temperature;
         volatile bool m_curr_state = 0;
 
+        //Private member functions that this class defines (overrides from the base):
         bool m_sendTorque(float torque_setpoint);
-        bool m_requestPosition();
         bool m_readMotorResponse() override;
 
-
-
-
-
+        //Private member functions exclusive for RMD Motors.
+        bool m_requestPosition();
 };

--- a/lib/RMD_Motor/RmdMotor.h
+++ b/lib/RMD_Motor/RmdMotor.h
@@ -32,6 +32,8 @@ class RmdMotor : public CanMotor{
         bool turnOff() override;
         bool setCurrentPositionAsZero() override;
         bool setCurrentPositionAsOrigin() override;
+        bool setTorque(float torque_setpoint) override;
+        bool setTorque(float torque_setpoint, unsigned long timeout_us) override;
 
     private:
         //Private member variables

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,9 +8,10 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-; [env:esp32doit-devkit-v1]
-; platform = espressif32
-; board = esp32doit-devkit-v1
+[env:esp32doit-devkit-v1]
+platform = espressif32
+board = esp32doit-devkit-v1
+framework = arduino
 
 [env:teensy41]
 platform = teensy

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "machine_state.h"
 #include "MitMotor.h"
 #include "RmdMotor.h"
+#include "array"
  
 #define CS_1 2
 #define INT_1 27
@@ -26,11 +27,23 @@ RmdMotor motor2(RmdMotor::RMD_X6, CS_2, INT_2, "RMD X6 1" );
 
 MachineStates current_state = MachineStates::PRINT_MENU;
 
+/*
+CanMotor * my_motors[6] = {
+    new MitMotor(MitMotor::AK_10, CS_1, INT_1, "AK_10 1"),
+    new RmdMotor(RmdMotor::RMD_X6, CS_2, INT_2, "RMD X6 1" )
+};
+auto & motori = (*my_motors);
+*/
+
+// std::array<CanMotor *, 6> my_motors = {
+//     new MitMotor(MitMotor::AK_10, CS_1, INT_1, "AK_10 1"),
+//     new RmdMotor(RmdMotor::RMD_X6, CS_2, INT_2, "RMD X6 1" )
+// };
+
 
 void setup()
 {
     Serial.begin(115200);
-
     pinMode(BOTON, INPUT_PULLUP);
     pinMode(AUX_PIN_1, OUTPUT);
     digitalWrite(AUX_PIN_1,LOW);
@@ -40,14 +53,13 @@ void setup()
         delay(100);
     }
 
+
     while(!motor2.initialize()){
         Serial.print("Retrying to connect to the MCP2515 of motor "); Serial.println(motor1.name());
         delay(100);
     }
 
-
     Serial.println("Initializedd succesfully");
-
 
 }
 
@@ -155,10 +167,10 @@ void loop ()
 
         case SET_TORQUE_ZERO:
             Serial.print("\nEstableciendo el torque a 0\n");
-            if (motor1.setTorque(0)) Serial.println("Current 0 setpoint sent to motor 1");
-            else Serial.println("Failed sending the message to motor 1");
-            if (motor2.setTorque(0)) Serial.println("Current 0 setpoint sent to motor 2");
-            else Serial.println("Failed sending the message to motor 2");
+            if (motor1.setTorque(0)) {Serial.print("Current 0 setpoint sent to "); Serial.println(motor1.name());}
+            else {Serial.print("Failed sending the message to "); Serial.println(motor1.name());}
+            if (motor2.setTorque(0)) {Serial.print("Current 0 setpoint sent to "); Serial.println(motor2.name());}
+            else {Serial.print("Failed sending the message to "); Serial.println(motor2.name());}
             current_state = MachineStates::PRINT_MENU;
             break;
 
@@ -178,11 +190,50 @@ void loop ()
             break;
 
         case REQUEST_POSITION:
-            Serial.print("\nSolicitando la posicion actual del motor\n");
-            #if MOTOR_RMD
-                if (motor1.requestPosition()) Serial.println("Sent CAN message to request position");
-                else Serial.println("Failed sending the message");
-            #endif
+            // {
+            // can_frame devnull;
+            // motor1.m_mcp2515.readMessage(&devnull);
+            // motor1.m_mcp2515.readMessage(&devnull);
+            // }
+            // Serial.print("Motor 1 running auto? "); Serial.println(motor1.m_is_auto_mode_running);
+            // Serial.print("Motor 2 running auto? "); Serial.println(motor2.m_is_auto_mode_running);
+
+            motor1.startAutoMode(motor1.ISR_callback);
+            motor2.startAutoMode(motor2.ISR_callback);
+
+            // Serial.println("TRYING TO RECOVER");
+            // motor1.m_emptyMCP2515buffer();
+            // motor1.m_mcp2515.clearInterrupts();
+
+            // motor2.m_emptyMCP2515buffer();
+            // motor2.m_mcp2515.clearInterrupts();
+            //pinMode(m_interrupt_pin, INPUT);
+            //attachInterrupt(digitalPinToInterrupt(m_interrupt_pin), ISR_callback, FALLING);
+            //SPI.usingInterrupt(digitalPinToInterrupt(m_interrupt_pin));
+            //m_last_response_time_ms = millis();
+            //motor1.m_sendTorque(m_torque_setpoint);
+
+
+            // Serial.print(motor1.name()); Serial.println(":");
+            // Serial.print("Status: "); Serial.println(motor1.m_mcp2515.getStatus(), BIN);
+            // Serial.print("Interrupt Mask: "); Serial.println(motor1.m_mcp2515.getInterruptMask(), BIN);
+            // Serial.print("Interrupts: "); Serial.println(motor1.m_mcp2515.getInterrupts(), BIN);
+            // Serial.print("Error Flags: "); Serial.println(motor1.m_mcp2515.getErrorFlags(), BIN);
+            // Serial.println();
+
+            // Serial.print(motor2.name()); Serial.println(":");
+            // Serial.print("Status: "); Serial.println(motor2.m_mcp2515.getStatus(), BIN);
+            // Serial.print("Interrupt Mask: "); Serial.println(motor2.m_mcp2515.getInterruptMask(), BIN);
+            // Serial.print("Interrupts: "); Serial.println(motor2.m_mcp2515.getInterrupts(), BIN);
+            // Serial.print("Error Flags: "); Serial.println(motor2.m_mcp2515.getErrorFlags(), BIN);
+
+            // Serial.println("Resetting MCP");
+            // motor1.m_mcp2515.reset();
+            // motor1.m_mcp2515.setBitrate(CAN_1000KBPS, MCP_16MHZ);
+            // motor1.m_mcp2515.setNormalMode();
+            // motor2.m_mcp2515.reset();
+            // motor2.m_mcp2515.setBitrate(CAN_1000KBPS, MCP_16MHZ);
+            // motor2.m_mcp2515.setNormalMode();
             current_state = MachineStates::PRINT_MENU;
             break;
 
@@ -200,26 +251,44 @@ void loop ()
             const uint16_t delay_us = 250;
             while (digitalRead(BOTON) == HIGH)
             {
+                bool print_once = true;
+                while(wait < delay_us)
+                {
+                    if (print_once)
+                    {
+                        print_once = false;
+                        // Serial.print("Position: "); Serial.print(motor1.position(), 4);
+                        // Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
+                        // Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
 
-                //while(wait < delay_us){}
-                //wait = 0;
+                        // Serial.print("Position 2: "); Serial.print(motor2.position(), 4);
+                        // Serial.print("\tTorque 2: "); Serial.print(motor2.torque(), 4);
+                        // Serial.print("\tVelocity 2: "); Serial.println(motor2.velocity(), 4);                   
+                        // Serial.println();
+                    }
+                }
+                wait = 0;
 
-                motor2.setTorque(0,2000);
-                motor1.setTorque(0,2000);
-                motor2.readMotorResponse(1000);
-                motor2.requestPosition();
-                motor1.readMotorResponse(2000);
-                motor2.readMotorResponse(2000);
+                if(!motor2.setTorque(0,2000)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor2.name()); }
+                else
+                {
+                    Serial.print("Position 2: "); Serial.print(motor2.position(), 4);
+                    Serial.print("\tTorque 2: "); Serial.print(motor2.torque(), 4);
+                    Serial.print("\tVelocity 2: "); Serial.println(motor2.velocity(), 4);                   
+                    Serial.println();
+                }
+                if(!motor1.setTorque(0,2000)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor1.name()); }
+                else
+                {
+                    Serial.print("Position: "); Serial.print(motor1.position(), 4);
+                    Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
+                    Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
+                }
+                if(!motor2.readMotorResponse(1000))  { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
+                if(!motor2.requestPosition()) { Serial.print("No se pudo solicitar respuesta a: "); Serial.println(motor2.name()); }
+                if(!motor1.readMotorResponse(2000)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor1.name()); }
+                if(!motor2.readMotorResponse(2000)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
 
-                // Serial.print("Position: "); Serial.print(motor1.position(), 4);
-                // Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
-                // Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
-
-                // Serial.print("Position 2: "); Serial.print(motor2.position(), 4);
-                // Serial.print("\tTorque 2: "); Serial.print(motor2.torque(), 4);
-                // Serial.print("\tVelocity 2: "); Serial.println(motor2.velocity(), 4);                   
-                // Serial.println();
-                
                 digitalWrite(AUX_PIN_1,!digitalRead(AUX_PIN_1));
             }
             current_state = MachineStates::PRINT_MENU;
@@ -254,12 +323,16 @@ void loop ()
         } break;
 
         case START_AUTO_MODE:
+            Serial.print("Starting auto mode: "); Serial.println(motor1.name());
+            Serial.print("Starting auto mode: "); Serial.println(motor2.name());
             motor1.startAutoMode([](){motor1.handleInterrupt();});
-            motor2.startAutoMode([](){motor2.handleInterrupt();});                        
+            motor2.startAutoMode([](){motor2.handleInterrupt();});
             current_state = PRINT_MENU;
             break;
 
         case STOP_AUTO_MODE:
+            Serial.print("Disabling auto mode: "); Serial.println(motor1.name());
+            Serial.print("Disabling auto mode: "); Serial.println(motor2.name());
             motor1.stopAutoMode();
             motor2.stopAutoMode();                        
             current_state = PRINT_MENU;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,6 +257,7 @@ void loop ()
                     if (print_once)
                     {
                         print_once = false;
+                        //Serial.println("Hi");
                         // Serial.print("Position: "); Serial.print(motor1.position(), 4);
                         // Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
                         // Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
@@ -269,7 +270,7 @@ void loop ()
                 }
                 wait = 0;
 
-                if(!motor2.setTorque(0,2000)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor2.name()); }
+                if(!motor2.setTorque(0,3000)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor2.name());}
                 else
                 {
                     Serial.print("Position 2: "); Serial.print(motor2.position(), 4);
@@ -277,7 +278,7 @@ void loop ()
                     Serial.print("\tVelocity 2: "); Serial.println(motor2.velocity(), 4);                   
                     Serial.println();
                 }
-                if(!motor1.setTorque(0,2000)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor1.name()); }
+                if(!motor1.setTorque(0,3000)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor1.name());}
                 else
                 {
                     Serial.print("Position: "); Serial.print(motor1.position(), 4);
@@ -286,8 +287,8 @@ void loop ()
                 }
                 if(!motor2.readMotorResponse(1000))  { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
                 if(!motor2.requestPosition()) { Serial.print("No se pudo solicitar respuesta a: "); Serial.println(motor2.name()); }
-                if(!motor1.readMotorResponse(2000)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor1.name()); }
-                if(!motor2.readMotorResponse(2000)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
+                if(!motor1.readMotorResponse(1500)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor1.name()); }
+                if(!motor2.readMotorResponse(1500)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
 
                 digitalWrite(AUX_PIN_1,!digitalRead(AUX_PIN_1));
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,48 +247,40 @@ void loop ()
         case SET_TORQUE_AND_READ:
         {
             Serial.println("\nVamos a escribir y leer continuamente");
-            elapsedMicros wait;
-            const uint16_t delay_us = 250;
+            elapsedMicros wait_to_print;
+            elapsedMicros wait_to_loop;
+            const uint16_t delay_loop_us = 25;
+            const uint16_t print_every_us = 5000;
             while (digitalRead(BOTON) == HIGH)
             {
-                bool print_once = true;
-                while(wait < delay_us)
-                {
-                    if (print_once)
-                    {
-                        print_once = false;
-                        //Serial.println("Hi");
-                        // Serial.print("Position: "); Serial.print(motor1.position(), 4);
-                        // Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
-                        // Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
+                while (wait_to_loop < delay_loop_us){}
+                wait_to_loop = 0;
+                if(wait_to_print > print_every_us){
+                    wait_to_print = 0;
+                    Serial.print("Position: "); Serial.print(motor1.position(), 4);
+                    Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
+                    Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
 
-                        // Serial.print("Position 2: "); Serial.print(motor2.position(), 4);
-                        // Serial.print("\tTorque 2: "); Serial.print(motor2.torque(), 4);
-                        // Serial.print("\tVelocity 2: "); Serial.println(motor2.velocity(), 4);                   
-                        // Serial.println();
-                    }
-                }
-                wait = 0;
-
-                if(!motor2.setTorque(0,3000)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor2.name());}
-                else
-                {
                     Serial.print("Position 2: "); Serial.print(motor2.position(), 4);
                     Serial.print("\tTorque 2: "); Serial.print(motor2.torque(), 4);
                     Serial.print("\tVelocity 2: "); Serial.println(motor2.velocity(), 4);                   
                     Serial.println();
                 }
-                if(!motor1.setTorque(0,3000)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor1.name());}
+
+                if(!motor2.setTorque(0)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor2.name());}
                 else
                 {
-                    Serial.print("Position: "); Serial.print(motor1.position(), 4);
-                    Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
-                    Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
+                    //Serial.println("HI");
                 }
-                if(!motor2.readMotorResponse(1000))  { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
-                if(!motor2.requestPosition()) { Serial.print("No se pudo solicitar respuesta a: "); Serial.println(motor2.name()); }
-                if(!motor1.readMotorResponse(1500)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor1.name()); }
-                if(!motor2.readMotorResponse(1500)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
+                if(!motor1.setTorque(0)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor1.name());}
+                else
+                {
+
+                }
+                // if(!motor2.readMotorResponse(1000))  { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
+                // if(!motor2.requestPosition()) { Serial.print("No se pudo solicitar respuesta a: "); Serial.println(motor2.name()); }
+                // if(!motor1.readMotorResponse(1500)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor1.name()); }
+                // if(!motor2.readMotorResponse(1500)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
 
                 digitalWrite(AUX_PIN_1,!digitalRead(AUX_PIN_1));
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,43 +3,41 @@
 #include "MitMotor.h"
 #include "RmdMotor.h"
 #include "array"
+#include <algorithm>
  
-#define CS_1 2
-#define INT_1 27
-#define CS_2 3
-#define INT_2 28
+#define NUM_MOTORS 2
 
+// const uint8_t CS_PINS [NUM_MOTORS] =        {2 , 3 };
+// const uint8_t INTERRUPT_PINS[NUM_MOTORS] =  {27, 28};
+#define CS_1 2
+#define CS_2 3
+#define INT_1 27
+#define INT_2 28
 
 #define BOTON 1
 #define AUX_PIN_1 9
 
 
-#define MOTOR_RMD 0
-#if MOTOR_RMD
-    RmdMotor motor1(RmdMotor::RMD_L5015, CS_1, "RMD_L5015");
-
-#else
-    MitMotor motor1(MitMotor::AK_10, CS_1, INT_1, "AK_10 1");
-    //MitMotor motor2(MitMotor::GIM, CS_2, INT_2, "GIM 1");
-#endif
-
-RmdMotor motor2(RmdMotor::RMD_X6, CS_2, INT_2, "RMD X6 1" );
-
 MachineStates current_state = MachineStates::PRINT_MENU;
 
-/*
-CanMotor * my_motors[6] = {
+
+CanMotor * motors_array[NUM_MOTORS] = {
     new MitMotor(MitMotor::AK_10, CS_1, INT_1, "AK_10 1"),
     new RmdMotor(RmdMotor::RMD_X6, CS_2, INT_2, "RMD X6 1" )
 };
-auto & motori = (*my_motors);
-*/
+size_t motorito = sizeof(motors_array) / sizeof(motors_array[0]);
+auto & my_motors = (*motors_array);
+size_t motoroto = sizeof(my_motors) / sizeof(my_motors[0]);
 
-// std::array<CanMotor *, 6> my_motors = {
+
+
+// std::array<CanMotor *, NUM_MOTORS> my_motors_std = {
 //     new MitMotor(MitMotor::AK_10, CS_1, INT_1, "AK_10 1"),
 //     new RmdMotor(RmdMotor::RMD_X6, CS_2, INT_2, "RMD X6 1" )
 // };
 
+
+std::array<float, NUM_MOTORS> torques;
 
 void setup()
 {
@@ -47,19 +45,33 @@ void setup()
     pinMode(BOTON, INPUT_PULLUP);
     pinMode(AUX_PIN_1, OUTPUT);
     digitalWrite(AUX_PIN_1,LOW);
+    delay(500);
 
-    while(!motor1.initialize()){
-        Serial.print("Retrying to connect to the MCP2515 of motor "); Serial.println(motor1.name());
-        delay(100);
+    Serial.print("Motorito is ");
+    Serial.print(motorito);
+    Serial.print("Motoroto is ");
+    Serial.print(motoroto);
+
+    // for (auto& motor : my_motors_std)
+    // {
+    //     while(!motor->initialize()){
+    //         Serial.print("Retrying to connect to the MCP2515 of motor "); Serial.println(motor->name());
+    //     }
+    // }
+    
+
+    for (auto i = 0; i < NUM_MOTORS; i++)
+    {
+        while(!my_motors[0].initialize())
+        {
+            Serial.print("Retrying to initialize "); Serial.print(my_motors[i].name()); Serial.print(" MCP2515");
+        }
+        while(!my_motors[0].turnOn())
+        {
+            Serial.print("Retrying to turn on "); Serial.println(my_motors[i].name());
+        }
     }
-
-
-    while(!motor2.initialize()){
-        Serial.print("Retrying to connect to the MCP2515 of motor "); Serial.println(motor1.name());
-        delay(100);
-    }
-
-    Serial.println("Initializedd succesfully");
+    Serial.println("All motors initializedd succesfully");
 
 }
 
@@ -141,106 +153,57 @@ void loop ()
 
         case ENABLE_MOTORS:
             Serial.println("\nEnabling Motor");
-            if (motor1.turnOn())
+            for (uint8_t i = 0; i < NUM_MOTORS; i++)
             {
-                Serial.print("Position: "); Serial.print(motor1.position(), 4);
-                Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
-                Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
-                Serial.println();
-            }
-            else Serial.println("No response");
+                if (my_motors[i].turnOn() ) {Serial.print("Turned on "); Serial.println(my_motors[i].name());}
+                else {Serial.print("Failed turning on "); Serial.println(my_motors[i].name());}
+            }            
             current_state = MachineStates::PRINT_MENU;
             break;
 
         case DISABLE_MOTORS:
             Serial.println("\nDisabling Motor");   
-            if (motor1.turnOff())
+            for (uint8_t i = 0; i < NUM_MOTORS; i++)
             {
-                Serial.print("Position: "); Serial.print(motor1.position(), 4);
-                Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
-                Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
-                Serial.println();
-            }
-            else Serial.println("No response");  
+                if (my_motors[i].turnOff() ) {Serial.print("Turned off "); Serial.println(my_motors[i].name());}
+                else {Serial.print("Failed turning off "); Serial.println(my_motors[i].name());}
+            }   
             current_state = MachineStates::PRINT_MENU;
             break;
 
         case SET_TORQUE_ZERO:
             Serial.print("\nEstableciendo el torque a 0\n");
-            if (motor1.setTorque(0)) {Serial.print("Current 0 setpoint sent to "); Serial.println(motor1.name());}
-            else {Serial.print("Failed sending the message to "); Serial.println(motor1.name());}
-            if (motor2.setTorque(0)) {Serial.print("Current 0 setpoint sent to "); Serial.println(motor2.name());}
-            else {Serial.print("Failed sending the message to "); Serial.println(motor2.name());}
+            for (uint8_t i = 0; i < NUM_MOTORS; i++)
+            {
+                if (my_motors[i].setTorque(0)) {Serial.print("Current 0 setpoint sent to "); Serial.println(my_motors[i].name());}
+                else {Serial.print("Failed setting torque cero to "); Serial.println(my_motors[i].name());}
+            }            
             current_state = MachineStates::PRINT_MENU;
             break;
 
         case READ_MOTOR_RESPONSE:
-            motor1.readMotorResponse();
-            motor2.readMotorResponse();
-            Serial.print("\nL Respuesta motores\n");
-            Serial.print("Position: "); Serial.print(motor1.position(), 4);
-            Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
-            Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
-
-            Serial.print("Position 2: "); Serial.print(motor2.position(), 4);
-            Serial.print("\tTorque 2: "); Serial.print(motor2.torque(), 4);
-            Serial.print("\tVelocity 2: "); Serial.println(motor2.velocity(), 4);
+            for (uint8_t i = 0; i < NUM_MOTORS; i++)
+            {       
+                if (my_motors[i].readMotorResponse())
+                {
+                    Serial.print("\nL Respuesta motores\n");
+                    Serial.print("Position: "); Serial.print(my_motors[i].position(), 4);
+                    Serial.print("\tTorque: "); Serial.print(my_motors[i].torque(), 4);
+                    Serial.print("\tVelocity: "); Serial.println(my_motors[i].velocity(), 4);
+                }
+                else {Serial.print("No response pending in "); Serial.print(my_motors[i].name()); Serial.print(" MCP2515 Buffer");}
+            }
 
             current_state = MachineStates::PRINT_MENU;
             break;
 
         case REQUEST_POSITION:
-            // {
-            // can_frame devnull;
-            // motor1.m_mcp2515.readMessage(&devnull);
-            // motor1.m_mcp2515.readMessage(&devnull);
-            // }
-            // Serial.print("Motor 1 running auto? "); Serial.println(motor1.m_is_auto_mode_running);
-            // Serial.print("Motor 2 running auto? "); Serial.println(motor2.m_is_auto_mode_running);
-
-            motor1.startAutoMode(motor1.ISR_callback);
-            motor2.startAutoMode(motor2.ISR_callback);
-
-            // Serial.println("TRYING TO RECOVER");
-            // motor1.m_emptyMCP2515buffer();
-            // motor1.m_mcp2515.clearInterrupts();
-
-            // motor2.m_emptyMCP2515buffer();
-            // motor2.m_mcp2515.clearInterrupts();
-            //pinMode(m_interrupt_pin, INPUT);
-            //attachInterrupt(digitalPinToInterrupt(m_interrupt_pin), ISR_callback, FALLING);
-            //SPI.usingInterrupt(digitalPinToInterrupt(m_interrupt_pin));
-            //m_last_response_time_ms = millis();
-            //motor1.m_sendTorque(m_torque_setpoint);
-
-
-            // Serial.print(motor1.name()); Serial.println(":");
-            // Serial.print("Status: "); Serial.println(motor1.m_mcp2515.getStatus(), BIN);
-            // Serial.print("Interrupt Mask: "); Serial.println(motor1.m_mcp2515.getInterruptMask(), BIN);
-            // Serial.print("Interrupts: "); Serial.println(motor1.m_mcp2515.getInterrupts(), BIN);
-            // Serial.print("Error Flags: "); Serial.println(motor1.m_mcp2515.getErrorFlags(), BIN);
-            // Serial.println();
-
-            // Serial.print(motor2.name()); Serial.println(":");
-            // Serial.print("Status: "); Serial.println(motor2.m_mcp2515.getStatus(), BIN);
-            // Serial.print("Interrupt Mask: "); Serial.println(motor2.m_mcp2515.getInterruptMask(), BIN);
-            // Serial.print("Interrupts: "); Serial.println(motor2.m_mcp2515.getInterrupts(), BIN);
-            // Serial.print("Error Flags: "); Serial.println(motor2.m_mcp2515.getErrorFlags(), BIN);
-
-            // Serial.println("Resetting MCP");
-            // motor1.m_mcp2515.reset();
-            // motor1.m_mcp2515.setBitrate(CAN_1000KBPS, MCP_16MHZ);
-            // motor1.m_mcp2515.setNormalMode();
-            // motor2.m_mcp2515.reset();
-            // motor2.m_mcp2515.setBitrate(CAN_1000KBPS, MCP_16MHZ);
-            // motor2.m_mcp2515.setNormalMode();
+            Serial.println("Muchas gracias por seleccionar esta opcion, pero este caso no se usa para nada ahorita.");
             current_state = MachineStates::PRINT_MENU;
             break;
 
         case SET_TORQUE:
-            Serial.print("\nSe ha establecido un valor torque (0.3)\n");
-            if (motor1.setTorque(0.3)) Serial.println("Current 0.3 setpoint sent");
-            else Serial.println("Failed sending the message");
+            Serial.println("Muchas gracias por seleccionar esta opcion, pero este caso no se usa para nada ahorita x2.");
             current_state = MachineStates::PRINT_MENU;
             break;
 
@@ -249,85 +212,90 @@ void loop ()
             Serial.println("\nVamos a escribir y leer continuamente");
             elapsedMicros wait_to_print;
             elapsedMicros wait_to_loop;
-            const uint16_t delay_loop_us = 25;
+            const uint16_t delay_loop_us = 250;
             const uint16_t print_every_us = 5000;
             while (digitalRead(BOTON) == HIGH)
             {
                 while (wait_to_loop < delay_loop_us){}
                 wait_to_loop = 0;
+                
+                for (uint8_t i = 0; i < NUM_MOTORS; i++)
+                {  
+                    if(!my_motors[i].setTorque(0)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(my_motors[i].name());}
+                }
+                
                 if(wait_to_print > print_every_us){
                     wait_to_print = 0;
-                    Serial.print("Position: "); Serial.print(motor1.position(), 4);
-                    Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
-                    Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
-
-                    Serial.print("Position 2: "); Serial.print(motor2.position(), 4);
-                    Serial.print("\tTorque 2: "); Serial.print(motor2.torque(), 4);
-                    Serial.print("\tVelocity 2: "); Serial.println(motor2.velocity(), 4);                   
-                    Serial.println();
+                    for (uint8_t i = 0; i < NUM_MOTORS; i++)
+                    {
+                        Serial.print(my_motors[i].name());
+                        Serial.print(":\tPosition: "); Serial.print(my_motors[i].position(), 4);
+                        Serial.print("\tTorque: "); Serial.print(my_motors[i].torque(), 4);
+                        Serial.print("\tVelocity: "); Serial.println(my_motors[i].velocity(), 4);                  
+                        Serial.println();
+                    }
                 }
-
-                if(!motor2.setTorque(0)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor2.name());}
-                else
-                {
-                    //Serial.println("HI");
-                }
-                if(!motor1.setTorque(0)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motor1.name());}
-                else
-                {
-
-                }
-                // if(!motor2.readMotorResponse(1000))  { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
-                // if(!motor2.requestPosition()) { Serial.print("No se pudo solicitar respuesta a: "); Serial.println(motor2.name()); }
-                // if(!motor1.readMotorResponse(1500)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor1.name()); }
-                // if(!motor2.readMotorResponse(1500)) { Serial.print("No se pudo leer respuesta de: "); Serial.println(motor2.name()); }
-
                 digitalWrite(AUX_PIN_1,!digitalRead(AUX_PIN_1));
             }
             current_state = MachineStates::PRINT_MENU;
         }break;
 
         case SET_POS_ORIGIN:
-            Serial.print("\nSe ha establecido la posicion actual como el origen\n");
-            if (motor1.setCurrentPositionAsOrigin()){
-                Serial.print("Position: "); Serial.print(motor1.position(), 4);
-                Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
-                Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
-            }
-            else 
+            Serial.print("\nEstableciendo posicion actual como el origen\n");
+            for (uint8_t i = 0; i < NUM_MOTORS; i++)
             {
-                Serial.println("Failed setting current position as origin");
+                Serial.print(my_motors[i].name());
+                if (my_motors[i].setCurrentPositionAsOrigin()){
+                    Serial.print(":\tPosition: "); Serial.print(my_motors[i].position(), 4);
+                    Serial.print("\tTorque: "); Serial.print(my_motors[i].torque(), 4);
+                    Serial.print("\tVelocity: "); Serial.println(my_motors[i].velocity(), 4);
                 }
+                else 
+                {
+                    Serial.println(":\tFailed setting current position as origin");
+                }
+            }
             current_state = MachineStates::PRINT_MENU;
             break;
 
         case SET_POS_ZERO:
         {
             Serial.print("\nSe ha establecido la posicion actual como zero del motor\n");
-            if (motor1.setCurrentPositionAsZero())
+            for (uint8_t i = 0; i < NUM_MOTORS; i++)
             {
-                Serial.print("Position: "); Serial.print(motor1.position(), 4);
-                Serial.print("\tTorque: "); Serial.print(motor1.torque(), 4);
-                Serial.print("\tVelocity: "); Serial.println(motor1.velocity(), 4);
-                Serial.println();
+                Serial.print(my_motors[i].name());
+                if (my_motors[i].setCurrentPositionAsZero())
+                {
+                    Serial.print("Position: "); Serial.print(my_motors[i].position(), 4);
+                    Serial.print("\tTorque: "); Serial.print(my_motors[i].torque(), 4);
+                    Serial.print("\tVelocity: "); Serial.println(my_motors[i].velocity(), 4);
+                }
+                else 
+                {
+                    Serial.println(":\tFailed setting current position as origin");
+                }
             }
-            else Serial.println("No response");
             current_state = PRINT_MENU;
         } break;
 
         case START_AUTO_MODE:
-            Serial.print("Starting auto mode: "); Serial.println(motor1.name());
-            Serial.print("Starting auto mode: "); Serial.println(motor2.name());
-            motor1.startAutoMode([](){motor1.handleInterrupt();});
-            motor2.startAutoMode([](){motor2.handleInterrupt();});
+            my_motors[0].startAutoMode([](){my_motors[0].handleInterrupt();});
+
+
+            for (uint8_t i = 0; i < NUM_MOTORS; i++)
+            {
+                Serial.print("Starting auto mode: "); Serial.println(my_motors[i].name());
+                //my_motors[i].startAutoMode([i](){my_motors[i].handleInterrupt();});
+            }
+
             current_state = PRINT_MENU;
             break;
 
         case STOP_AUTO_MODE:
-            Serial.print("Disabling auto mode: "); Serial.println(motor1.name());
-            Serial.print("Disabling auto mode: "); Serial.println(motor2.name());
-            motor1.stopAutoMode();
-            motor2.stopAutoMode();                        
+            //Serial.print("Disabling auto mode: "); Serial.println(motor1.name());
+            //Serial.print("Disabling auto mode: "); Serial.println(motor2.name());
+            //motor1.stopAutoMode();
+            //motor2.stopAutoMode();                        
             current_state = PRINT_MENU;
             break;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,10 @@ void setup()
     digitalWrite(AUX_PIN_1,LOW);
     delay(500);
 
+    Serial.println("Sizes:");
+    Serial.println(sizeof(uint8_t));
+    Serial.println(sizeof(MitMotor));
+    Serial.println(sizeof(RmdMotor));
 
     for (auto & motor : motors)
     {
@@ -266,6 +270,12 @@ void loop ()
             motors[0]->startAutoMode([](){motors[0]->handleInterrupt();});
             Serial.print("Starting auto mode for:"); Serial.println(motors[1]->name());
             motors[1]->startAutoMode([](){motors[1]->handleInterrupt();});
+
+            //void(*p[1])() = {motors[0]->handleInterrupt};
+            //p[0] = motors[0]->handleInterrupt;
+
+            //auto hi = motors[0]->handleInterrupt;
+
             current_state = PRINT_MENU;
             break;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,7 +194,7 @@ void loop ()
             Serial.println("\nVamos a escribir y leer continuamente");
             elapsedMicros wait_to_print;
             elapsedMicros wait_to_loop;
-            const uint16_t delay_loop_us = 150;
+            const uint16_t delay_loop_us = 0;
             const uint16_t print_every_us = 5000;
             while (digitalRead(BOTON) == HIGH)
             {
@@ -203,7 +203,7 @@ void loop ()
                 
                 for (uint8_t i = 0; i < NUM_MOTORS; i++)
                 {  
-                    if(!motors[i]->setTorque(0)) { Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motors[i]->name());}
+                    if(!motors[i]->setTorque(0)) { /*Serial.print("No se pudo enviar torque 0 a: "); Serial.println(motors[i]->name());*/}
                 }
                 
                 if(wait_to_print > print_every_us)

--- a/src/main_bkp.cpp
+++ b/src/main_bkp.cpp
@@ -1,38 +1,31 @@
-#include "Arduino.h"
+/*#include "Arduino.h"
 #include "machine_state.h"
 #include "MitMotor.h"
 #include "RmdMotor.h"
  
 #define CS_1 2
-#define INT_1 27
-
 #define BOTON 1
 #define MOTOR_RMD 0
 #if MOTOR_RMD
     RmdMotor motor1(RmdMotor::RMD_L5015, CS_1, "RMD_L5015");
 
 #else
-    MitMotor motor1(MitMotor::AK_10, CS_1, INT_1, "AK_10 1");
+    MitMotor motor1(MitMotor::AK_10, CS_1, "AK_10 1");
 #endif
 
 MachineStates current_state = MachineStates::PRINT_MENU;
-
 
 void setup()
 {
     Serial.begin(115200);
 
-    pinMode(BOTON, INPUT_PULLUP);
-    pinMode(INT_1, INPUT);
+    pinMode(BOTON, INPUT_PULLUP);   
 
     while(!motor1.initialize()){
         Serial.print("Retrying to connect to the MCP2515 of motor "); Serial.println(motor1.name());
         delay(100);
     }
-
     Serial.println("Initialized succesfully");
-
-    motor1.startInterrupt([](){motor1.handleInterrupt();});
 }
 
 void loop ()
@@ -214,3 +207,7 @@ void loop ()
     }
 
 }
+
+
+
+*/


### PR DESCRIPTION
Auto mode:

- Uses MCP2515 interrupt pin for handling message reception. 
- Not needed anymore to use readReasponse(), interrupt callback manages motor responses.
- Single interface for all motor types, now it is possible to create an array of motors (array of pointers to the base class CanMotor).